### PR TITLE
Use logger.hasHandlers() to setup fallback logging

### DIFF
--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -207,7 +207,7 @@ class Conf:
 logger = logging.getLogger("django-q")
 
 # Set up standard logging handler in case there is none
-if not logger.handlers:
+if not logger.hasHandlers():
     logger.setLevel(level=getattr(logging, Conf.LOG_LEVEL))
     logger.propagate = False
     formatter = logging.Formatter(


### PR DESCRIPTION
Instead of checking if the django-q logger has any handlers directly, use the hasHandlers [1] method, which will check if any parent loggers have handlers as well.

This fixes a bug where django-q configures it's own logging even though the root logger has a handler set

 1. https://docs.python.org/3/library/logging.html#logging.Logger.hasHandlers