### PR TITLE
Fix install command and remove old warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Installation
 
 -  Install the latest version with pip::
 
-    $ pip install django-q
+    $ pip install django-q2
 
 
 -  Add `django_q` to your `INSTALLED_APPS` in your projects `settings.py`::
@@ -60,7 +60,7 @@ Installation
 
     $ python manage.py migrate
 
--  Choose a message `broker <https://django-q2.readthedocs.org/en/latest/brokers.html>`__ , configure and install the appropriate client library.
+-  Choose a message `broker <https://django-q2.readthedocs.org/en/latest/brokers.html>`__, configure and install the appropriate client library.
 
 Read the full documentation at `https://django-q2.readthedocs.org <https://django-q2.readthedocs.org>`__
 

--- a/docs/group.rst
+++ b/docs/group.rst
@@ -49,11 +49,6 @@ Instead of :func:`result_group` you can also use :func:`fetch_group` to return a
 
 Getting results by using :func:`result_group` is of course much faster than using :func:`fetch_group`, but it doesn't offer the benefits of Django's queryset functions.
 
-.. note::
-
-   Calling ``Queryset.values`` for the result on Django 1.7 or lower will return a list of encoded results.
-   If you can't upgrade to Django 1.8, use list comprehension or an iterator to return decoded results.
-
 You can also access group functions from a task result instance:
 
 .. code-block:: python

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -31,9 +31,8 @@ Django Q2 is tested for Python 3.7, 3.8, 3.9 and 3.10
 
 -  `Django <https://www.djangoproject.com>`__
 
-    Django Q2 aims to use as much of Django's standard offerings as possible
+    Django Q2 aims to use as much of Django's standard offerings as possible.
     The code is tested against Django versions `2.2.x` and `3.2.x`.
-    Please note that Django versions below 2.0 do not support Python 3.7
 
 -  `Django-picklefield <https://github.com/gintas/django-picklefield>`__
 
@@ -134,11 +133,6 @@ Python
 ~~~~~~
 Current tests are performed with 3.7, 3.8, 3.9 and 3.10
 If you do encounter any regressions with earlier versions, please submit an issue on `github <https://github.com/GDay/django-q2>`__
-
-.. note::
-
-    Django releases before 1.11 are not supported on Python 3.6
-    Django releases before 2.0 are not supported on Python 3.7
 
 Open-source packages
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- fix django q2 install command and remove space
- remove warnings for very old versions