### PR TITLE
Move baseconv/base62 deprecation warning for Django 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/GDay/django-q2/tree/HEAD)
 
+**Merged pull requests:**
+- Fix: Deprecation warning for Django 5.x 
 
 ## [v1.4.3](https://github.com/GDay/django-q2/tree/v1.4.3) (2022-11-07)
 
@@ -9,7 +11,6 @@
 
 - Fix: func reference in admin https://github.com/GDay/django-q2/pull/28
 - Add python 3.11 support and remove 3.7 (as it was never supported by this package anyway)
-
 
 ## [v1.4.2](https://github.com/GDay/django-q2/tree/v1.4.2) (2022-10-22)
 

--- a/django_q/core_signing.py
+++ b/django_q/core_signing.py
@@ -5,7 +5,12 @@ import zlib
 from django.core.signing import BadSignature, JSONSerializer, SignatureExpired
 from django.core.signing import Signer as Sgnr
 from django.core.signing import TimestampSigner as TsS
-from django.core.signing import b64_decode, dumps, base62
+from django.core.signing import b64_decode, dumps
+try:
+    from django.core.signing import base62
+except ImportError:
+    # For django < 4.0
+    from django.utils.baseconv import base62
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_bytes, force_str
 

--- a/django_q/core_signing.py
+++ b/django_q/core_signing.py
@@ -5,8 +5,7 @@ import zlib
 from django.core.signing import BadSignature, JSONSerializer, SignatureExpired
 from django.core.signing import Signer as Sgnr
 from django.core.signing import TimestampSigner as TsS
-from django.core.signing import b64_decode, dumps
-from django.utils import baseconv
+from django.core.signing import b64_decode, dumps, base62
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_bytes, force_str
 
@@ -69,7 +68,7 @@ class TimestampSigner(Signer, TsS):
         """
         result = super(TimestampSigner, self).unsign(value)
         value, timestamp = result.rsplit(self.sep, 1)
-        timestamp = baseconv.base62.decode(timestamp)
+        timestamp = base62.decode(timestamp)
         if max_age is not None:
             if isinstance(max_age, datetime.timedelta):
                 max_age = max_age.total_seconds()


### PR DESCRIPTION
fixes #33