### PR TITLE
Remove pytz dependency

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -6,7 +6,6 @@ import socket
 import traceback
 import uuid
 from datetime import datetime, timedelta
-from pytz import timezone as pytz_timezone
 from multiprocessing import Event, Process, Value, current_process
 from time import sleep
 

--- a/django_q/tests/test_scheduler.py
+++ b/django_q/tests/test_scheduler.py
@@ -1,8 +1,11 @@
 import os
-import pytz
 from datetime import datetime, timedelta
 from multiprocessing import Event, Value
 from unittest import mock
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -90,7 +93,7 @@ def test_scheduler_daylight_saving_time_daily(broker, monkeypatch):
     # 28th of March 2021 is the day when sunlight saving starts (at 2 am)
 
     monkeypatch.setattr(Conf, "TIME_ZONE", "Europe/Amsterdam")
-    tz = pytz.timezone('Europe/Amsterdam')
+    tz = zoneinfo.ZoneInfo('Europe/Amsterdam')
     broker.list_key = "scheduler_test:q"
     # Let's start a schedule at 1 am on the 27th of March. This is in AMS timezone.
     # So, 2021-03-27 00:00:00 when saved (due to TZ being Amsterdam and saved in UTC)

--- a/django_q/tests/test_scheduler.py
+++ b/django_q/tests/test_scheduler.py
@@ -31,7 +31,7 @@ else:
     try:
         from zoneinfo import ZoneInfo
     except ImportError:
-        from backports.zoninfo import ZoneInfo
+        from backports.zoneinfo import ZoneInfo
 
 
 @pytest.fixture

--- a/django_q/tests/test_scheduler.py
+++ b/django_q/tests/test_scheduler.py
@@ -34,7 +34,6 @@ else:
         from backports.zoninfo import ZoneInfo
 
 
-
 @pytest.fixture
 def broker(monkeypatch) -> Broker:
     """

--- a/django_q/utils.py
+++ b/django_q/utils.py
@@ -60,7 +60,7 @@ def get_func_repr(func):
 def localtime(value=None) -> datetime:
     """Override for timezone.localtime to deal with naive times and local times"""
     if settings.USE_TZ:
-        if settings.USE_DEPRECATED_PYTZ:
+        if django.VERSION >= (4, 0) and settings.USE_DEPRECATED_PYTZ:
             import pytz
 
             convert_to_tz = pytz.timezone(Conf.TIME_ZONE)

--- a/django_q/utils.py
+++ b/django_q/utils.py
@@ -16,7 +16,8 @@ else:
     try:
         from zoneinfo import ZoneInfo
     except ImportError:
-        from backports.zoninfo import ZoneInfo
+        from backports.zoneinfo import ZoneInfo
+
 
 # credits: https://stackoverflow.com/a/4131114
 # Made them aware of timezone

--- a/django_q/utils.py
+++ b/django_q/utils.py
@@ -55,7 +55,14 @@ def get_func_repr(func):
 def localtime(value=None) -> datetime:
     """Override for timezone.localtime to deal with naive times and local times"""
     if settings.USE_TZ:
-        return timezone.localtime(value=value, timezone=zoneinfo.ZoneInfo(Conf.TIME_ZONE))
+        if settings.USE_DEPRECATED_PYTZ:
+            import pytz
+
+            convert_to_tz = pytz.timezone(Conf.TIME_ZONE)
+        else:
+            convert_to_tz = zoneinfo.ZoneInfo(Conf.TIME_ZONE)
+
+        return timezone.localtime(value=value, timezone=convert_to_tz)
     if value is None:
         return datetime.now()
     else:

--- a/django_q/utils.py
+++ b/django_q/utils.py
@@ -3,16 +3,20 @@ import calendar
 import inspect
 from datetime import date
 
+import django
 from django.utils import timezone
 from django.conf import settings
 
 from django_q.conf import Conf
 
-try:
-    import zoneinfo
-except ImportError:
-    from backports import zoneinfo
-
+if django.VERSION < (4, 0):
+    # pytz is the default in django 3.2. Remove when no support for 3.2
+    from pytz import timezone as ZoneInfo
+else:
+    try:
+        from zoneinfo import ZoneInfo
+    except ImportError:
+        from backports.zoninfo import ZoneInfo
 
 # credits: https://stackoverflow.com/a/4131114
 # Made them aware of timezone
@@ -60,7 +64,7 @@ def localtime(value=None) -> datetime:
 
             convert_to_tz = pytz.timezone(Conf.TIME_ZONE)
         else:
-            convert_to_tz = zoneinfo.ZoneInfo(Conf.TIME_ZONE)
+            convert_to_tz = ZoneInfo(Conf.TIME_ZONE)
 
         return timezone.localtime(value=value, timezone=convert_to_tz)
     if value is None:

--- a/django_q/utils.py
+++ b/django_q/utils.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import pytz
 import calendar
 import inspect
 from datetime import date
@@ -8,6 +7,12 @@ from django.utils import timezone
 from django.conf import settings
 
 from django_q.conf import Conf
+
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
+
 
 # credits: https://stackoverflow.com/a/4131114
 # Made them aware of timezone
@@ -50,7 +55,7 @@ def get_func_repr(func):
 def localtime(value=None) -> datetime:
     """Override for timezone.localtime to deal with naive times and local times"""
     if settings.USE_TZ:
-        return timezone.localtime(value=value, timezone=pytz.timezone(Conf.TIME_ZONE))
+        return timezone.localtime(value=value, timezone=zoneinfo.ZoneInfo(Conf.TIME_ZONE))
     if value is None:
         return datetime.now()
     else:


### PR DESCRIPTION
For some reason, I was under the assumption that pytz was a required lib by Django and the default. But it's not and it's actually deprecated. The default is `zoneinfo` for Django 4.x and higher, which I have now used to replace pytz with.

Django allows for a setting to use `pytz`, so I have enabled that as well for this library:
https://github.com/django/django/blob/2d676ee119696250a8b76c69ec9d9b799ddeb6b4/django/utils/timezone.py#L71-L82

Edit: it's required for Django 3.2, and it's not in Django 4.x