### PR TITLE
Fix missing setup file for "No matching distribution" error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,5 +82,4 @@ profile = "black"
 multi_line_output = 3
 
 [tool.poetry.build]
-generate-setup-file = false
 script = "django_compilemessages.py"


### PR DESCRIPTION
Fixes #68 